### PR TITLE
Fix get_build_log

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,3 +5,4 @@ v0.1.3, 2020-02-21 -- Add back get_collection_entries
 v0.1.4, 2020-02-21 -- Add SnapBuilder.get_snap
 v0.2.0, 2020-02-24 -- Combine ImageBuilder and SnapBuilder into one Launchpad class
 v0.2.1, 2020-02-25 -- Added get_build and get_build_log methods
+v0.2.2, 2020-02-25 -- Fixed get_build_log method to convert get_build response to json

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -220,7 +220,7 @@ class Launchpad:
         """
         Return the log content of a snap build
         """
-        build = self.get_snap_build(snap_name, build_id)
+        build = self.get_snap_build(snap_name, build_id).json()
 
         response = self.session.request("GET", build["build_log_url"])
         response.raise_for_status()

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -214,13 +214,13 @@ class Launchpad:
         return self._request(
             path=f"~{self.username}/+snap/{lp_snap['name']}/+build/{build_id}",
             method="GET",
-        )
+        ).json()
 
     def get_snap_build_log(self, snap_name, build_id):
         """
         Return the log content of a snap build
         """
-        build = self.get_snap_build(snap_name, build_id).json()
+        build = self.get_snap_build(snap_name, build_id)
 
         response = self.session.request("GET", build["build_log_url"])
         response.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.2.1",
+    version="0.2.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
get_build_log currently tries to read the raw response as some kind of dict. This PR makes sure the response is parsed as JSON.