### PR TITLE
Build Snaps for defined architectures in snapcraft.yaml

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,3 +7,4 @@ v0.2.0, 2020-02-24 -- Combine ImageBuilder and SnapBuilder into one Launchpad cl
 v0.2.1, 2020-02-25 -- Added get_build and get_build_log methods
 v0.2.2, 2020-02-25 -- Fixed get_build_log method to convert get_build response to json
 v0.2.3, 2020-02-26 -- Added get_snap_builds
+v0.2.4, 2020-02-28 -- Changed build_snap method to use requestBuilds instead of requestBuild

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -187,7 +187,7 @@ class Launchpad:
         lp_snap = self.get_snap_by_store_name(snap_name)
 
         data = {
-            "ws.op": "requestBuild",
+            "ws.op": "requestBuilds",
             "channels": "snapcraft,apt",
             "archive": (
                 "https://api.launchpad.net/devel/ubuntu/+archive/primary"
@@ -195,13 +195,7 @@ class Launchpad:
             "pocket": "Updates",
         }
 
-        archs = ["amd64", "arm64", "armhf", "i386", "ppc64el", "s390x"]
-
-        for arch in archs:
-            data["distro_arch_series"] = f"/ubuntu/xenial/{arch}"
-            self._request(
-                path=lp_snap["self_link"][32:], method="POST", data=data
-            )
+        self._request(path=lp_snap["self_link"][32:], method="POST", data=data)
 
         return True
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.2.3",
+    version="0.2.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
Some Snaps have architectures defined in the snapcraft.yaml with the previous API call we were ignoring them.