### PR TITLE
Disable auto_build

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,3 +9,4 @@ v0.2.2, 2020-02-25 -- Fixed get_build_log method to convert get_build response t
 v0.2.3, 2020-02-26 -- Added get_snap_builds
 v0.2.4, 2020-02-28 -- Changed build_snap method to use requestBuilds instead of requestBuild
 v0.2.5, 2020-03-10 -- Enable store upload when creating a Snap and added is_snap_building method
+v0.2.6, 2020-03-10 -- Create snaps with auto_build disabled

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -178,7 +178,7 @@ class Launchpad:
             "store_series": "/+snappy-series/16",
             "store_channels": ["edge"],
             "store_upload": "true",
-            "auto_build": "true",
+            "auto_build": "false",
         }
 
         self._request(path="+snaps", method="POST", data=data)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.2.5",
+    version="0.2.6",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
We don't seem to need the `auto_build` property enabled for snapcraft.io