### PR TITLE
Set "archive", "pocket" and "channels" correctly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,3 +11,5 @@ v0.2.4, 2020-02-28 -- Changed build_snap method to use requestBuilds instead of 
 v0.2.5, 2020-03-10 -- Enable store upload when creating a Snap and added is_snap_building method
 v0.2.6, 2020-03-10 -- Create snaps with auto_build disabled
 v0.2.7, 2020-03-11 -- Added cancel_snap_builds method
+v0.2.8, 2020-03-16 -- Trigger build with correct parameters
+

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -184,10 +184,7 @@ class Launchpad:
         self._request(path="+snaps", method="POST", data=data)
 
         # Authorize uploads to the store from this user
-        data = {
-            "ws.op": "completeAuthorization",
-            "root_macaroon": macaroon,
-        }
+        data = {"ws.op": "completeAuthorization", "root_macaroon": macaroon}
 
         self._request(
             path=f"~{self.username}/+snap/{lp_snap_name}/",
@@ -216,13 +213,11 @@ class Launchpad:
             path=lp_snap["pending_builds_collection_link"][32:]
         )
 
-        data = {
-            "ws.op": "cancel",
-        }
+        data = {"ws.op": "cancel"}
 
         for build in builds:
             self._request(
-                path=build["self_link"][32:], method="POST", data=data,
+                path=build["self_link"][32:], method="POST", data=data
             )
 
         return True
@@ -233,15 +228,16 @@ class Launchpad:
         """
 
         lp_snap = self.get_snap_by_store_name(snap_name)
+        channels = lp_snap.get("auto_build_channels")
 
         data = {
             "ws.op": "requestBuilds",
-            "channels": "snapcraft,apt",
-            "archive": (
-                "https://api.launchpad.net/devel/ubuntu/+archive/primary"
-            ),
-            "pocket": "Updates",
+            "archive": lp_snap["auto_build_archive_link"],
+            "pocket": lp_snap["auto_build_pocket"],
         }
+
+        if channels:
+            data["channels"] = channels
 
         self._request(path=lp_snap["self_link"][32:], method="POST", data=data)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.2.7",
+    version="0.2.8",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
When building a snap, set the correct values for these, as per #13

Fixes #13

QA
--

I made a PR that is running this version of this module:
https://github.com/canonical-web-and-design/snapcraft.io/pull/2614

Try building a snap with that version of the site.