### PR TITLE
Added auth_consumer in the constructor method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,3 +16,4 @@ v0.2.9, 2020-04-02 -- Added delete_snap method
 v0.3.0, 2020-04-14 -- Add create_system_build_webhook, and make `request` method part of public interface
 v0.3.1, 2020-04-16 -- Add ability to pass metadata to build_image
 v0.4.0, 2020-04-17 -- Webhooks should always have secret
+v0.5.0, 2020-04-23 -- Added auth_consumer in the constructor method

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -54,11 +54,14 @@ class Launchpad:
         },
     }
 
-    def __init__(self, username, token, secret, session):
+    def __init__(self, username, token, secret, session, auth_consumer=None):
         """
         This requires a session object because in the normal use-case
         we will be passing through a `talisker.session.get_session()`
         """
+
+        if not auth_consumer:
+            auth_consumer = username
 
         self.username = username
         self.session = session
@@ -66,7 +69,7 @@ class Launchpad:
         self.session.headers["Authorization"] = (
             f'OAuth oauth_version="1.0", '
             f'oauth_signature_method="PLAINTEXT", '
-            f"oauth_consumer_key={username}, "
+            f"oauth_consumer_key={auth_consumer}, "
             f'oauth_token="{token}", '
             f'oauth_signature="&{secret}"'
         )
@@ -105,7 +108,7 @@ class Launchpad:
 
         webhooks = self.get_collection_entries(
             "https://api.launchpad.net/devel/"
-            f"~{self.username.replace('.', '')}/"
+            f"~{self.username}/"
             f"+livefs/ubuntu/{codename}/{project}/webhooks"
         )
 
@@ -124,7 +127,7 @@ class Launchpad:
         return self.request(
             (
                 "https://api.launchpad.net/devel/"
-                f"~{self.username.replace('.', '')}/"
+                f"~{self.username}/"
                 f"+livefs/ubuntu/{codename}/{project}"
             ),
             method="post",
@@ -179,7 +182,7 @@ class Launchpad:
         return self.request(
             (
                 "https://api.launchpad.net/devel/"
-                f"~{self.username.replace('.', '')}/"
+                f"~{self.username}/"
                 f"+livefs/ubuntu/{codename}/{project}"
             ),
             method="post",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.4.0",
+    version="0.5.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -25,10 +25,11 @@ class LaunchpadTest(VCRTestCase):
             session=requests.Session(),
         )
         self.lp_for_images = Launchpad(
-            username="image.build",
+            username="imagebuild",
             token=getenv("IMAGE_BUILDS_TOKEN", "secret"),
             secret=getenv("IMAGE_BUILDS_SECRET", "secret"),
             session=requests.Session(),
+            auth_consumer="image.build",
         )
         return super().setUp()
 


### PR DESCRIPTION
This is to try to fix the issues commented here:

https://github.com/canonical-web-and-design/canonicalwebteam.launchpad/pull/16#discussion_r409892647

As we discussed there removing the dots in the username string is not a good thing for the Snapcraft username and as we plan to use this module in both places we need to support a different string for the oauth_consumer_key in the authentication header.