### PR TITLE
Make sure that image_format is set to 'ubuntu-image'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,3 +17,4 @@ v0.3.0, 2020-04-14 -- Add create_system_build_webhook, and make `request` method
 v0.3.1, 2020-04-16 -- Add ability to pass metadata to build_image
 v0.4.0, 2020-04-17 -- Webhooks should always have secret
 v0.5.0, 2020-04-23 -- Added auth_consumer in the constructor method
+v0.5.1, 2020-04-28 -- Fix image builds by providing image_format=ubuntu-image

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -166,6 +166,7 @@ class Launchpad:
             "subarch": arch_info["subarch"],
             "extra_snaps": snaps,
             "project": project,
+            "image_format": "ubuntu-image",
         }
 
         data = {

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.5.0",
+    version="0.5.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
Another way would be to configure all the livefs LP builders to just default to an image_format 'ubuntu-image', but that requires someone with access to ~imagebuild. This means changing for instance this one here:
https://launchpad.net/~imagebuild/+livefs/ubuntu/xenial/ubuntu-core

We need to specify 'ubuntu-image' as the image format as otherwise live-build will attempt to build the image in a traditional way, without using ubuntu-image (which is does not work, is not supported and deprecated).

Not sure if there is a test suite here that will need adjusting.