### PR TITLE
Fix method is_snap_building

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,3 +20,4 @@ v0.5.0, 2020-04-23 -- Added auth_consumer in the constructor method
 v0.5.1, 2020-04-28 -- Fix image builds by providing image_format=ubuntu-image
 v0.6.0, 2020-04-29 -- Remove classic from image builder support
 v0.7.0, 2020-05-01 -- Update secret in system build webhooks
+v0.7.1, 2020-05-11 -- Fix method is_snap_building

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -264,7 +264,7 @@ class Launchpad:
         lp_snap = self.get_snap_by_store_name(snap_name)
         pending_builds = self.request(
             lp_snap["pending_builds_collection_link"]
-        )
+        ).json()
         return pending_builds["total_size"] > 0
 
     def cancel_snap_builds(self, snap_name):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.7.0",
+    version="0.7.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
This method was broken and causing errors in the poller script.

# QA
Follow the QA steps here:
https://github.com/canonical-web-and-design/snapcraft-poller-script/pull/18