### PR TITLE
Added get_builders_status method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,3 +21,4 @@ v0.5.1, 2020-04-28 -- Fix image builds by providing image_format=ubuntu-image
 v0.6.0, 2020-04-29 -- Remove classic from image builder support
 v0.7.0, 2020-05-01 -- Update secret in system build webhooks
 v0.7.1, 2020-05-11 -- Fix method is_snap_building
+v0.7.2, 2020-05-15 -- Added get_builders_status method

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.7.1",
+    version="0.7.2",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(

--- a/tests/cassettes/LaunchpadTest.test_06_get_builders_status.yaml
+++ b/tests/cassettes/LaunchpadTest.test_06_get_builders_status.yaml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.launchpad.net/devel/builders?ws.op=getBuildQueueSizes
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/zXNQQqEMAwF0KuUrKU0sUnbXGVwURDRhQqdYWCQ3n0qxV34//FzwXcrH1BzQd5n
+        8e16kaPBAJk5/96DSepEebROxCPC1Kpc9nXp8oaoPignyxJd4Ef0LUy3GBVFiWxkCdHDVFt4nMfz
+        utY/YkIfa4cAAAA=
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '119'
+      Content-Security-Policy:
+      - frame-ancestors 'self';
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 May 2020 09:41:22 GMT
+      Keep-Alive:
+      - timeout=60, max=100
+      Server:
+      - zope.server.http (HTTP)
+      Strict-Transport-Security:
+      - max-age=15552000
+      Vary:
+      - Accept,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Launchpad-Revision:
+      - 0385b538081bc4718df6fb844a3afc89729c94ce
+      X-Lazr-Notifications:
+      - '[]'
+      X-Powered-By:
+      - Zope (www.zope.org), Python (www.python.org)
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: Ok
+version: 1

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -78,3 +78,10 @@ class LaunchpadTest(VCRTestCase):
     def test_05_delete_snap(self):
         result = self.lp_for_snaps.delete_snap("new-test-snap")
         self.assertEqual(True, result)
+
+    def test_06_get_builders_status(self):
+        result = self.lp_for_snaps.get_builders_status()
+
+        for architecture in result.values():
+            self.assertIn("pending_builds", architecture.keys())
+            self.assertIn("estimated_duration", architecture.keys())


### PR DESCRIPTION
# QA
In a virtual python3 environment run:
`pip3 install git+https://github.com/jkfran/canonicalwebteam.launchpad.git@get-builders-status#egg=canonicalwebteam.launchpad==0.7.2`
Then run ipython3 with the following code to use the new method:
```
from canonicalwebteam.launchpad.models import Launchpad
from requests import session
s = session()

launchpad = Launchpad(                                                                          
    username="build.snapcraft.io",
    token="ASKME",
    secret="ASKME",
    session=s
)
launchpad.get_builders_status()
```

You will get a JSON object with all the architectures and the estimated time, the result should match with https://launchpad.net/builders