### PR TITLE
Update get_builders_status response to obtain the estimated time per architecture

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,3 +22,4 @@ v0.6.0, 2020-04-29 -- Remove classic from image builder support
 v0.7.0, 2020-05-01 -- Update secret in system build webhooks
 v0.7.1, 2020-05-11 -- Fix method is_snap_building
 v0.7.2, 2020-05-15 -- Added get_builders_status method
+v0.7.3, 2020-05-15 -- Update get_builders_status response to obtain the estimated time per architecture

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.7.2",
+    version="0.7.3",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(
@@ -18,6 +18,10 @@ setup(
     packages=find_packages(),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["python-gnupg>=0.4.6"],
+    install_requires=[
+        "python-gnupg>=0.4.6",
+        "pytimeparse==1.1.8",
+        "humanize==2.4.0",
+    ],
     tests_require=["vcrpy-unittest"],
 )

--- a/tests/cassettes/LaunchpadTest.test_06_get_builders_status.yaml
+++ b/tests/cassettes/LaunchpadTest.test_06_get_builders_status.yaml
@@ -14,23 +14,18 @@ interactions:
     uri: https://api.launchpad.net/devel/builders?ws.op=getBuildQueueSizes
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAA/zXNQQqEMAwF0KuUrKU0sUnbXGVwURDRhQqdYWCQ3n0qxV34//FzwXcrH1BzQd5n
-        8e16kaPBAJk5/96DSepEebROxCPC1Kpc9nXp8oaoPignyxJd4Ef0LUy3GBVFiWxkCdHDVFt4nMfz
-        utY/YkIfa4cAAAA=
+      string: '{"virt": {}, "nonvirt": {}}'
     headers:
       Connection:
       - Keep-Alive
-      Content-Encoding:
-      - gzip
       Content-Length:
-      - '119'
+      - '27'
       Content-Security-Policy:
       - frame-ancestors 'self';
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 May 2020 09:41:22 GMT
+      - Thu, 21 May 2020 09:21:25 GMT
       Keep-Alive:
       - timeout=60, max=100
       Server:
@@ -38,13 +33,313 @@ interactions:
       Strict-Transport-Security:
       - max-age=15552000
       Vary:
-      - Accept,Accept-Encoding
+      - Accept
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - SAMEORIGIN
       X-Launchpad-Revision:
-      - 0385b538081bc4718df6fb844a3afc89729c94ce
+      - 1f7bc749b40714a4cc10f5e4d787118a78037035
+      X-Lazr-Notifications:
+      - '[]'
+      X-Powered-By:
+      - Zope (www.zope.org), Python (www.python.org)
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.launchpad.net/devel/builders?ws.op=getBuildersForQueue&ws.show=total_size&processor=%2F%2Bprocessors%2Famd64&virtualized=true
+  response:
+    body:
+      string: '99'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'self';
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 May 2020 09:21:25 GMT
+      Keep-Alive:
+      - timeout=60, max=99
+      Server:
+      - zope.server.http (HTTP)
+      Strict-Transport-Security:
+      - max-age=15552000
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Launchpad-Revision:
+      - 1f7bc749b40714a4cc10f5e4d787118a78037035
+      X-Lazr-Notifications:
+      - '[]'
+      X-Powered-By:
+      - Zope (www.zope.org), Python (www.python.org)
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.launchpad.net/devel/builders?ws.op=getBuildersForQueue&ws.show=total_size&processor=%2F%2Bprocessors%2Farm64&virtualized=true
+  response:
+    body:
+      string: '85'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'self';
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 May 2020 09:21:25 GMT
+      Keep-Alive:
+      - timeout=60, max=98
+      Server:
+      - zope.server.http (HTTP)
+      Strict-Transport-Security:
+      - max-age=15552000
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Launchpad-Revision:
+      - 1f7bc749b40714a4cc10f5e4d787118a78037035
+      X-Lazr-Notifications:
+      - '[]'
+      X-Powered-By:
+      - Zope (www.zope.org), Python (www.python.org)
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.launchpad.net/devel/builders?ws.op=getBuildersForQueue&ws.show=total_size&processor=%2F%2Bprocessors%2Farmhf&virtualized=true
+  response:
+    body:
+      string: '85'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'self';
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 May 2020 09:21:25 GMT
+      Keep-Alive:
+      - timeout=60, max=97
+      Server:
+      - zope.server.http (HTTP)
+      Strict-Transport-Security:
+      - max-age=15552000
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Launchpad-Revision:
+      - 1f7bc749b40714a4cc10f5e4d787118a78037035
+      X-Lazr-Notifications:
+      - '[]'
+      X-Powered-By:
+      - Zope (www.zope.org), Python (www.python.org)
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.launchpad.net/devel/builders?ws.op=getBuildersForQueue&ws.show=total_size&processor=%2F%2Bprocessors%2Fi386&virtualized=true
+  response:
+    body:
+      string: '99'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'self';
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 May 2020 09:21:25 GMT
+      Keep-Alive:
+      - timeout=60, max=96
+      Server:
+      - zope.server.http (HTTP)
+      Strict-Transport-Security:
+      - max-age=15552000
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Launchpad-Revision:
+      - 1f7bc749b40714a4cc10f5e4d787118a78037035
+      X-Lazr-Notifications:
+      - '[]'
+      X-Powered-By:
+      - Zope (www.zope.org), Python (www.python.org)
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.launchpad.net/devel/builders?ws.op=getBuildersForQueue&ws.show=total_size&processor=%2F%2Bprocessors%2Fppc64el&virtualized=true
+  response:
+    body:
+      string: '29'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'self';
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 May 2020 09:21:26 GMT
+      Keep-Alive:
+      - timeout=60, max=95
+      Server:
+      - zope.server.http (HTTP)
+      Strict-Transport-Security:
+      - max-age=15552000
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Launchpad-Revision:
+      - 1f7bc749b40714a4cc10f5e4d787118a78037035
+      X-Lazr-Notifications:
+      - '[]'
+      X-Powered-By:
+      - Zope (www.zope.org), Python (www.python.org)
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: Ok
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.launchpad.net/devel/builders?ws.op=getBuildersForQueue&ws.show=total_size&processor=%2F%2Bprocessors%2Fs390x&virtualized=true
+  response:
+    body:
+      string: '20'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '2'
+      Content-Security-Policy:
+      - frame-ancestors 'self';
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 21 May 2020 09:21:26 GMT
+      Keep-Alive:
+      - timeout=60, max=94
+      Server:
+      - zope.server.http (HTTP)
+      Strict-Transport-Security:
+      - max-age=15552000
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Launchpad-Revision:
+      - 1f7bc749b40714a4cc10f5e4d787118a78037035
       X-Lazr-Notifications:
       - '[]'
       X-Powered-By:

--- a/tests/test_launchpad.py
+++ b/tests/test_launchpad.py
@@ -83,5 +83,6 @@ class LaunchpadTest(VCRTestCase):
         result = self.lp_for_snaps.get_builders_status()
 
         for architecture in result.values():
-            self.assertIn("pending_builds", architecture.keys())
+            self.assertIn("pending_jobs", architecture.keys())
+            self.assertIn("total_jobs_duration", architecture.keys())
             self.assertIn("estimated_duration", architecture.keys())


### PR DESCRIPTION
# QA
In a virtual python3 environment run:
`pip3 install git+https://github.com/jkfran/canonicalwebteam.launchpad.git@update-builders-status#egg=canonicalwebteam.launchpad==0.7.3`
Then run ipython3 with the following code to use the new method:

* Ask me for the client secrets or use the ones you have set in your .env.local for Snapcraft.io

```
from canonicalwebteam.launchpad.models import Launchpad
from requests import session
s = session()

launchpad = Launchpad(                                                                          
    username="build.snapcraft.io",
    token="ASKME",
    secret="ASKME",
    session=s
)
launchpad.get_builders_status()
```

You will get a JSON object with all the architectures and the estimated time, the result should match with https://launchpad.net/builders