### PR TITLE
For image builds, set channel explicitly to 'stable'

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,3 +23,4 @@ v0.7.0, 2020-05-01 -- Update secret in system build webhooks
 v0.7.1, 2020-05-11 -- Fix method is_snap_building
 v0.7.2, 2020-05-15 -- Added get_builders_status method
 v0.7.3, 2020-05-15 -- Update get_builders_status response to obtain the estimated time per architecture
+v0.7.4, 2020-05-22 -- Always use stable channel of snaps for building core images

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -204,6 +204,7 @@ class Launchpad:
             "subarch": arch_info["subarch"],
             "extra_snaps": snaps,
             "project": project,
+            "channel": "stable",
             "image_format": "ubuntu-image",
         }
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.7.3",
+    version="0.7.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
As otherwise livecd-rootfs defaults to edge. And we should build images out of stable by default.