### PR TITLE
Update get_snap_builds method to return builds with the status "Needs building"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,3 +25,4 @@ v0.7.2, 2020-05-15 -- Added get_builders_status method
 v0.7.3, 2020-05-15 -- Update get_builders_status response to obtain the estimated time per architecture
 v0.7.4, 2020-05-22 -- Always use stable channel of snaps for building core images
 v0.7.5, 2020-05-22 -- Fix methods get_snap and get_snap_build
+v0.7.6, 2020-05-22 -- The method get_snap_builds is now able to return builds with the status "Needs building"

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -356,15 +356,23 @@ class Launchpad:
 
         return True
 
-    def get_snap_builds(self, snap_name):
+    def get_snap_builds(self, snap_name, pending_builds=True):
         """
         Return list of builds from a Snap from the Launchpad API
         """
         lp_snap = self.get_snap_by_store_name(snap_name)
 
-        # Remove first part of the URL
-        builds = self.get_collection_entries(lp_snap["builds_collection_link"])
+        builds = self.get_collection_entries(
+            lp_snap["completed_builds_collection_link"]
+        )
 
+        # Include pending builds
+        if pending_builds:
+            builds += self.get_collection_entries(
+                lp_snap["pending_builds_collection_link"]
+            )
+
+        # All of them are ordered by descending creation date
         return sorted(builds, key=lambda x: x["datecreated"], reverse=True)
 
     def get_snap_build(self, snap_name, build_id):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.launchpad",
-    version="0.7.5",
+    version="0.7.6",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url=(


### PR DESCRIPTION
## QA
You can QA this version running Snapcraft locally using this branch:
https://github.com/canonical-web-and-design/snapcraft.io/pull/2824