### PR TITLE
Make build_image take architecture as an optional argument

### DIFF
--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -177,15 +177,20 @@ class Launchpad:
             },
         )
 
-    def build_image(self, board, system, snaps, author_info, gpg_passphrase):
+    def build_image(self, board, system, snaps, author_info, gpg_passphrase, arch=None):
         """
         `board` is something like "raspberrypi3",
         `system` is something like "classic6418.04"
+        `arch` is something like "armhf"
         """
 
         system_year = re.match(r"^[^\d]+(?:64)?(\d{2})(\.\d{2})?$", system)[1]
         codename = self.system_codenames[system_year]
         arch_info = self.board_architectures[board][system]
+
+        if arch:
+            arch_info["arch"] = arch
+
         project = "ubuntu-core"
 
         if system.startswith("classic"):

--- a/canonicalwebteam/launchpad/models.py
+++ b/canonicalwebteam/launchpad/models.py
@@ -177,7 +177,9 @@ class Launchpad:
             },
         )
 
-    def build_image(self, board, system, snaps, author_info, gpg_passphrase, arch=None):
+    def build_image(
+        self, board, system, snaps, author_info, gpg_passphrase, arch=None
+    ):
         """
         `board` is something like "raspberrypi3",
         `system` is something like "classic6418.04"


### PR DESCRIPTION
## Done

- Added an optional architecture argument to `Launchpad.build_image` for compatibility with [this change](https://github.com/canonical-web-and-design/ubuntu.com/pull/8142) made to ubuntu.com/core/build.

## Issue / Card

Fixes: web-squad#3090